### PR TITLE
Minor fixes

### DIFF
--- a/demonstrator_firmware/firmware/cfg/regionizer_stream_cdc_pf_puppi_sim.dep
+++ b/demonstrator_firmware/firmware/cfg/regionizer_stream_cdc_pf_puppi_sim.dep
@@ -15,12 +15,12 @@ src cdc_and_deserializer.vhd
 src cdc_bram_fifo.vhd
 src serial2parallel.vhd
 src parallel2serial.vhd
-include -c post_sort post_sort.dep
-include -c l1pf_hls/multififo_regionizer/vhdl regionizer.dep 
+include -c post_sort: post_sort.dep
+include -c multififo_regionizer:vhdl regionizer.dep 
 
-include -c ip_cores_firmware/pfHGCal_3ns_ii4 top.dep 
-include -c ip_cores_firmware/puppiHGCal_3ns_ii4_charged top.dep 
-include -c ip_cores_firmware/puppiHGCal_3ns_ii4_neutral top.dep 
+include -c ip_cores_firmware:pfHGCal_240MHz_ii4 top.dep 
+include -c ip_cores_firmware:puppiHGCal_240MHz_ii4_charged top.dep 
+include -c ip_cores_firmware:puppiHGCal_240MHz_ii4_neutral top.dep 
 
 # generic
 src -c emp-fwk:components/ttc emp_ttc_decl.vhd

--- a/demonstrator_firmware/firmware/cfg/tdemux_regionizer_cdc_pf_puppi_stream_sort_top.dep
+++ b/demonstrator_firmware/firmware/cfg/tdemux_regionizer_cdc_pf_puppi_stream_sort_top.dep
@@ -33,3 +33,4 @@ addrtab -c emp-fwk:components/payload emp_payload.xml
 src -c emp-fwk:components/payload ../ucf/emp_simple_payload.tcl
 include -c emp-fwk:boards/vcu118
 src emp_project_decl.vhd
+setup -f vhdl2008.tcl

--- a/demonstrator_firmware/firmware/hdl/emp_payload_tdemux_regionizer_cdc_pf_puppi_sort.vhd
+++ b/demonstrator_firmware/firmware/hdl/emp_payload_tdemux_regionizer_cdc_pf_puppi_sort.vhd
@@ -94,7 +94,7 @@ architecture rtl of emp_payload is
 
 
         -- Puppi: 360 MHz stuff
-        signal puppi_out  : w64s(NPUPPI - 1 downto 0);
+        signal puppi_out  : w64s(NPUPPIFINALSORTED - 1 downto 0);
         signal puppi_start, puppi_read, puppi_done, puppi_valid : STD_LOGIC;
         signal puppi_empty : STD_LOGIC_VECTOR(NTKSTREAM+NCALOSTREAM-1 downto 0);
         signal puppi_out_stream: w64s(NPUPPISTREAM360 - 1 downto 0);
@@ -115,7 +115,7 @@ begin
     end process export_rst240;
 
 
-    algo_payload : entity work.tdemux_regionizer_cdc_pf_puppi
+    algo_payload : entity work.tdemux_regionizer_cdc_pf_puppi_sort
         port map(clk => clk_p, clk240 => clk_payload(0), 
                  rst => '0', --rst_loc(0), 
                  rst240 => '0', --rst240, 
@@ -221,7 +221,7 @@ begin
     end generate;
 
     puppi_streamer : entity work.parallel2serial
-                generic map(NITEMS => NPUPPI, NSTREAM => NPUPPISTREAM360)
+                generic map(NITEMS => NPUPPIFINALSORTED, NSTREAM => NPUPPISTREAM360)
                 port map( ap_clk => clk_p,
                           roll   => puppi_done,
                           data_in  => puppi_out,


### PR DESCRIPTION
A few minor fixes.
For the tdemux_regionizer_cdc_pf_puppi_sort project:
- Set all VHDL files to VHDL 2008, otherwise Vivado complains about the BitonicSort
- Use the `tdemux_regionizer_cdc_pf_puppi_sort` entity rather than `tdemux_regionizer_cdc_pf_puppi`
- Use `NPUPPIFINALSORTED` not `NPUPPI` for the number of output objects

For the ipbb simulation dep file:
- Change the components path to reflect the project structure when using the project scripts

